### PR TITLE
refactor(group_theory/cyclic): adjust file to reflect changes in the elaborator

### DIFF
--- a/group_theory/cyclic.lean
+++ b/group_theory/cyclic.lean
@@ -27,7 +27,7 @@ lemma mk_succ_ne_zero {n i : nat} : ∀ {P}, mk (succ i) P ≠ zero n :=
 assume P Pe, absurd (veq_of_eq Pe) !succ_ne_zero
 
 lemma madd_mk_mod {n i j : nat} : madd (mk_mod n i) (mk_mod n j) = mk_mod n (i+j) :=
-eq_of_veq begin rewrite [*val_mk, mod_add_mod, add_mod_mod] end
+eq_of_veq begin esimp [madd, mk_mod], rewrite [ mod_add_mod, add_mod_mod ] end
 
 definition diff [reducible] (i j : nat) :=
 if (i < j) then (j - i) else (i - j)
@@ -357,7 +357,7 @@ lemma rotl_id : ∀ {n : nat}, @rotl n n = id
   begin rewrite [rotl_succ', P], apply rotl_zero end
 
 lemma rotl_to_zero {n i : nat} : rotl i (mk_mod n i) = zero n :=
-eq_of_veq begin rewrite [↑rotl, val_madd, *val_mk, mod_add_mod, add_mod_mod, -succ_mul, mul_mod_right] end
+eq_of_veq begin rewrite [↑rotl, val_madd], esimp [mk_mod], rewrite [ mod_add_mod, add_mod_mod, -succ_mul, mul_mod_right] end
 
 lemma rotl_compose : ∀ {n : nat} {j k : nat}, (@rotl n j) ∘ (rotl k) = rotl (j + k)
 | 0        := take j k, funext take i, elim0 i
@@ -366,12 +366,12 @@ lemma rotl_compose : ∀ {n : nat} {j k : nat}, (@rotl n j) ∘ (rotl k) = rotl 
   end
 
 lemma rotr_rotl : ∀ {n : nat} (m : nat) {i : fin n}, rotr m (rotl m i) = i
-| 0        := take m i, elim0 i
-| (succ n) := take m i, calc (-(mk_mod n (n*m))) + ((mk_mod n (n*m)) + i) = i : neg_add_cancel_left
+| 0            := take m i, elim0 i
+| (nat.succ n) := take m i, calc (-(mk_mod n (n*m))) + ((mk_mod n (n*m)) + i) = i : by rewrite neg_add_cancel_left
 
 lemma rotl_rotr : ∀ {n : nat} (m : nat), (@rotl n m) ∘ (rotr m) = id
-| 0        := take m, funext take i, elim0 i
-| (succ n) := take m, funext take i, calc (mk_mod n (n*m)) + (-(mk_mod n (n*m)) + i) = i : add_neg_cancel_left
+| 0            := take m, funext take i, elim0 i
+| (nat.succ n) := take m, funext take i, calc (mk_mod n (n*m)) + (-(mk_mod n (n*m)) + i) = i : add_neg_cancel_left
 
 lemma rotl_succ {n : nat} : (rotl 1) ∘ (@succ n) = lift_succ :=
 funext (take i, eq_of_veq (begin rewrite [↑compose, ↑rotl, ↑madd, mul_one n, ↑mk_mod, mod_add_mod, ↑lift_succ, val_succ, -succ_add_eq_succ_add, add_mod_self_left, mod_eq_of_lt (lt.trans (is_lt i) !lt_succ_self), -val_lift] end))
@@ -393,7 +393,7 @@ lemma rotl_eq_rotl : ∀ {n : nat}, map (rotl 1) (upto n) = list.rotl (upto n)
   congruence,
     rewrite [map_map], congruence, exact rotl_succ,
     rewrite [map_singleton], congruence, rewrite [↑rotl, mul_one n, ↑mk_mod, ↑zero, ↑maxi, ↑madd],
-      congruence, rewrite [ mod_add_mod, nat.add_zero, mod_eq_of_lt !lt_succ_self]
+      congruence, rewrite [ mod_add_mod, nat.add_zero, mod_eq_of_lt !lt_succ_self ]
   end
 
 definition seq [reducible] (A : Type) (n : nat) := fin n → A
@@ -453,11 +453,11 @@ eq_of_feq (funext take f, calc
                       ... = f ∘ (rotl (j+i)) : rotl_compose)
 
 lemma rotl_perm_pow_eq : ∀ {i : nat}, (rotl_perm A n 1) ^ i = rotl_perm A n i
-| 0 := begin rewrite [pow_zero, ↑rotl_perm, perm_one, -eq_iff_feq, *perm.f_mk, rotl_seq_zero]  end
+| 0 := begin rewrite [pow_zero, ↑rotl_perm, perm_one, -eq_iff_feq], esimp, rewrite rotl_seq_zero  end
 | (succ i) := begin rewrite [pow_succ, rotl_perm_pow_eq, rotl_perm_mul, one_add] end
 
 lemma rotl_perm_pow_eq_one : (rotl_perm A n 1) ^ n = 1 :=
-eq.trans rotl_perm_pow_eq (eq_of_feq begin rewrite [perm.f_mk, ↑rotl_fun, rotl_id] end)
+eq.trans rotl_perm_pow_eq (eq_of_feq begin esimp [rotl_perm], rewrite [↑rotl_fun, rotl_id] end)
 
 -- needs A to have at least two elements!
 lemma rotl_perm_pow_ne_one (Pex : ∃ a b : A, a ≠ b) : ∀ i, i < n → (rotl_perm A (succ n) 1)^(succ i) ≠ 1 :=
@@ -470,5 +470,4 @@ lemma rotl_perm_order (Pex : ∃ a b : A, a ≠ b) : order (rotl_perm A (succ n)
 order_of_min_pow rotl_perm_pow_eq_one (rotl_perm_pow_ne_one Pex)
 
 end rotg
-
 end group

--- a/group_theory/pgroup.lean
+++ b/group_theory/pgroup.lean
@@ -10,7 +10,6 @@ import data algebra.group algebra.group_power algebra.group_bigops .cyclic .finf
 open nat fin list algebra function subtype
 
 section
-check @tag
 lemma dinj_tag {A : Type} (P : A → Prop) : dinj P tag :=
 take a₁ a₂ Pa₁ Pa₂ Pteq, subtype.no_confusion Pteq (λ Pe Pqe, Pe)
 
@@ -46,20 +45,15 @@ map (λ l, cons (Prodl l id)⁻¹ l) (all_lists_of_len n)
 
 open fin fintype
 
+section
 variable [deceqA : decidable_eq A]
 include deceqA
 
 definition all_prodseq_eq_one (n : nat) : list (seq A (succ n)) :=
 dmap (λ l, length l = card (fin (succ n))) list_to_fun (all_prodl_eq_one A n)
+end
 
-end defs
-
-section defs
-
-variables {A : Type} [ambA : group A] [finA : fintype A]
-include ambA finA
-
-open fin
+variable {A}
 
 definition prodseq {n : nat} (s : seq A n) : A := Prodl (upto n) s
 
@@ -68,14 +62,7 @@ include deceqA
 
 definition peo [reducible] {n : nat} (s : seq A n) := prodseq s = 1
 
-end defs
-
-section defs
-
-variables (A : Type) [ambA : group A] [finA : fintype A] [deceqA : decidable_eq A]
-include ambA finA deceqA
-
-open fin
+variable (A)
 
 definition peo_seq (n : nat) := {s : seq A (succ n) | peo s}
 
@@ -192,12 +179,7 @@ local attribute perm.f [coercion]
 definition rotl_peo_seq (n : nat) (m : nat) (s : peo_seq A n) : peo_seq A n :=
 tag (rotl_perm A (succ n) m (elt_of s)) (rotl_perm_peo_of_peo (has_property s))
 
-end defs
-
-section
-variables {A : Type} [ambA : group A] [finA : fintype A] [deceqA : decidable_eq A]
-include ambA finA deceqA
-
+variable {A}
 local attribute perm.f [coercion]
 
 lemma rotl_peo_seq_zero {n : nat} : rotl_peo_seq A n 0 = id :=
@@ -214,33 +196,24 @@ lemma rotl_peo_seq_inj {n m : nat} : injective (rotl_peo_seq A n m) :=
 take ps₁ ps₂, subtype.destruct ps₁ (λ s₁ P₁, subtype.destruct ps₂ (λ s₂ P₂,
   assume Peq, tag_eq (rotl_fun_inj (dinj_tag peo _ _ Peq))))
 
-end
-
-section defs
-variables (A : Type) [ambA : group A] [finA : fintype A] [deceqA : decidable_eq A]
-include ambA finA deceqA
-open fin fintype
+variable (A)
 
 definition rotl_perm_ps [reducible] (n m : nat) : perm (peo_seq A n) :=
 perm.mk (rotl_peo_seq A n m) rotl_peo_seq_inj
 
-end defs
-
-section
-variables {A : Type} [ambA : group A] [finA : fintype A] [deceqA : decidable_eq A] {n : nat}
-include ambA finA deceqA
-
+variable {A}
+variables {n : nat}
 variable [d : decidable_eq (peo_seq A n)]
 include d
 
 lemma rotl_perm_ps_pow_eq : ∀ {i : nat}, (rotl_perm_ps A n 1)^i = (rotl_perm_ps A n i)
-| 0 := begin rewrite [pow_zero (rotl_perm_ps A n 1), @perm_one (peo_seq A n), -eq_iff_feq, *perm.f_mk, rotl_peo_seq_zero] end
+| 0 := begin rewrite [pow_zero (rotl_perm_ps A n 1), @perm_one (peo_seq A n), -eq_iff_feq], esimp [rotl_perm_ps], rewrite [rotl_peo_seq_zero] end
 | (succ i) := begin rewrite [pow_succ (rotl_perm_ps A n 1), rotl_perm_ps_pow_eq, -(one_add i), -eq_iff_feq, ↑rotl_perm_ps, -rotl_peo_seq_compose] end
 
 lemma rotl_perm_ps_pow_eq_one : (rotl_perm_ps A n 1) ^ (succ n) = 1 :=
-eq.trans rotl_perm_ps_pow_eq (eq_of_feq begin rewrite [perm.f_mk] end)
+eq.trans rotl_perm_ps_pow_eq (eq_of_feq begin esimp [rotl_perm_ps], rewrite [rotl_peo_seq_id] end)
 
-end
+end defs
 
 end cauchy
 end group


### PR DESCRIPTION
I have been trying to improve the performance of Lean's elaborator.
The first step is to have special support for "projections" in the elaborator.
I added the following computational rule (to the elaborator onle, the kernel was not modified)

```
pr_i (S.mk A x_1 ... x_n) ===> x_i
```

where `pr_i` is the i-th projection of the structure `S`.
This makes a different for the algebraic hierarchy. Without this extra rule, we have to unfold `pr_i` which uses `S.rec`. For big structures such as `ordered_field`, the projections are quite big.

That being said, this change affects the elaboration algorithm. For example, `val_mk` is just reflexivity since `val (mk a b)` reduces to `a`. I adjusted your files. If your prefer the previous behavior, you can recover  it by defining `fin` as an inductive datatype instead of a structure. Moreover, for `fin` the optimization does not make a difference since it has only two fields.

Best wishes,
Leo
