### PR TITLE
feat(group_theory/cyclic): eliminate ambiguity

### DIFF
--- a/group_theory/cyclic.lean
+++ b/group_theory/cyclic.lean
@@ -323,7 +323,7 @@ definition upto_step : ∀ {n : nat}, fin.upto (succ n) = (map succ (upto n))++[
 
 section
 local attribute group_of_add_group [instance]
-
+local infix ^ := algebra.pow
 lemma pow_eq_mul {n : nat} {i : fin (succ n)} : ∀ {k : nat}, i^k = mk_mod n (i*k)
 | 0        := by rewrite [pow_zero]
 | (succ k) := begin


### PR DESCRIPTION
Given (i : fin (succ n)) (k : nat), the term (i^k) is ambiguous.
It has two possible intepretations:
1- (nat.pow (fin.val i) k)
2- (algebra.pow i k)

We eliminate the ambiguity by defining a local notation

   local infix ^ := algebra.pow

Local notation always overrides existing notation.

This modification will also make sure the file is correctly processed even after we change the order of the notation declarations.
